### PR TITLE
Remove `dockerImageId` from CWL files.

### DIFF
--- a/_posts/0008-01-01-Introduction_to_CWL.md
+++ b/_posts/0008-01-01-Introduction_to_CWL.md
@@ -157,7 +157,6 @@ The command.yml files specify how to run a given command for a step in the workf
 
 <span class="na" tabindex="0" data-toggle="popover" data-trigger="focus" data-content="field indicating any additional requirements when running the gunzip command">requirements</span><span class="pi">:</span>
   <span class="pi">-</span> <span class="na" tabindex="0" data-toggle="popover" data-trigger="focus" data-content="field indicating the class of the requirement">class</span><span class="pi">:</span> <span class="s" tabindex="0" data-toggle="popover" data-trigger="focus" data-content="indicates that the command needs to run with docker">DockerRequirement</span>
-    <span class="na" tabindex="0" data-toggle="popover" data-trigger="focus" data-content="field indicating the name of the docker image on your computer">dockerImageId</span><span class="pi">:</span> <span class="s" tabindex="0" data-toggle="popover" data-trigger="focus" data-content="indicates the docker image name is ubuntu:xenial">ubuntu:xenial</span>
     <span class="na" tabindex="0" data-toggle="popover" data-trigger="focus" data-content="field indicating the name of the docker image to pull if no image id is found locally">dockerPull</span><span class="pi">:</span> <span class="s" tabindex="0" data-toggle="popover" data-trigger="focus" data-content="indicates the docker image name to pull is ubuntu:xenial">ubuntu:xenial</span>
 
 <span class="na" tabindex="0" data-toggle="popover" data-trigger="focus" data-content="field specifying the inputs for this command">inputs</span><span class="pi">:</span>

--- a/assets/CWL/bam_index.cwl
+++ b/assets/CWL/bam_index.cwl
@@ -8,7 +8,6 @@ baseCommand: [ "index" ]
 
 requirements:
   - class: DockerRequirement
-    dockerImageId: mgibio/samtools:1.9
     dockerPull: mgibio/samtools:1.9
   - class: InitialWorkDirRequirement
     listing:

--- a/assets/CWL/bwa_index.cwl
+++ b/assets/CWL/bwa_index.cwl
@@ -14,7 +14,6 @@ inputs:
 
 requirements:
   - class: DockerRequirement
-    dockerImageId: biocontainers/bwa:0.7.15
     dockerPull: biocontainers/bwa:0.7.15
   - class: InitialWorkDirRequirement
     listing:

--- a/assets/CWL/bwa_mem.cwl
+++ b/assets/CWL/bwa_mem.cwl
@@ -8,7 +8,6 @@ baseCommand: [ "bwa", "mem" ]
 
 requirements:
   - class: DockerRequirement
-    dockerImageId: biocontainers/bwa:0.7.15
     dockerPull: biocontainers/bwa:0.7.15
 
 inputs:

--- a/assets/CWL/gunzip.cwl
+++ b/assets/CWL/gunzip.cwl
@@ -10,7 +10,6 @@ arguments: [ "-c" ]
 
 requirements:
   - class: DockerRequirement
-    dockerImageId: ubuntu:xenial
     dockerPull: ubuntu:xenial
 
 inputs:

--- a/assets/CWL/index_fa.cwl
+++ b/assets/CWL/index_fa.cwl
@@ -8,7 +8,6 @@ baseCommand: [ "faidx" ]
 
 requirements:
   - class: DockerRequirement
-    dockerImageId: mgibio/samtools:1.9
     dockerPull: mgibio/samtools:1.9
   - class: InitialWorkDirRequirement
     listing:

--- a/assets/CWL/sam2bam.cwl
+++ b/assets/CWL/sam2bam.cwl
@@ -8,7 +8,6 @@ baseCommand: [ "view" ]
 
 requirements:
   - class: DockerRequirement
-    dockerImageId: mgibio/samtools:1.9
     dockerPull: mgibio/samtools:1.9
 
 arguments:

--- a/assets/CWL/sam2fastq.cwl
+++ b/assets/CWL/sam2fastq.cwl
@@ -16,7 +16,6 @@ arguments:
 
 requirements:
   - class: DockerRequirement
-    dockerImageId: broadinstitute/picard:2.18.2
     dockerPull: broadinstitute/picard:2.18.2
 
 inputs:

--- a/assets/CWL/sort_bam.cwl
+++ b/assets/CWL/sort_bam.cwl
@@ -8,7 +8,6 @@ baseCommand: [ "sort" ]
 
 requirements:
   - class: DockerRequirement
-    dockerImageId: mgibio/samtools:1.9
     dockerPull: mgibio/samtools:1.9
   - class: InitialWorkDirRequirement
     listing:


### PR DESCRIPTION
Rely on the `dockerPull` to indicate the image.